### PR TITLE
Use native Promise or setImmediate if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promiscuous",
-  "version": "0.7.0",
+  "version": "0.7.0-set-timeout",
   "description": "A minimal and fast promise implementation",
   "author": "Ruben Verborgh <ruben.verborgh@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promiscuous",
-  "version": "0.7.0-set-timeout",
+  "version": "0.7.0-native-set-immediate",
   "description": "A minimal and fast promise implementation",
   "author": "Ruben Verborgh <ruben.verborgh@gmail.com>",
   "license": "MIT",

--- a/promiscuous.js
+++ b/promiscuous.js
@@ -75,7 +75,7 @@
 
   // Finalizes the promise by resolving/rejecting it with the transformed value
   function finalize(promise, resolve, reject, value, transform) {
-    setTimeout(function () {
+    var fn = function () {
       try {
         // Transform the value through and check whether it's a promise
         value = transform(value);
@@ -91,7 +91,13 @@
           transform.call(value, resolve, reject);
       }
       catch (error) { reject(error); }
-    }, 1);
+    }
+    // Don't polyfill setImmediate, but use it if it's available.
+    if (window.setImmediate) {
+      window.setImmediate(fn);
+    } else {
+      setTimeout(fn, 0);
+    }
   }
 
   // Export the main module

--- a/promiscuous.js
+++ b/promiscuous.js
@@ -1,5 +1,11 @@
 /**@license MIT-promiscuous-©Ruben Verborgh*/
 (function (func, obj) {
+  // If Promise is defined globally when this runs, just use that.
+  if (window.Promise) {
+    module.exports = window.Promise;
+    return;
+  }
+
   // Type checking utility function
   function is(type, item) { return (typeof item)[0] == type; }
 


### PR DESCRIPTION
This should give our version of Promiscuous more correct functionality. I could've sworn we already default to native Promise, but testing the lib directly in Chrome looked like it wasn't doing that. That behavior was kinda okay since we were only promises internally, but once we start using them as return values that we expose to customers, we'll want them to be the real thing.

The reason I changed this lib originally was because `setImmediate` was pulling in a polyfill that was messing up some customer's code, hence the explicit use of `window.setImmediate`. Hopefully that scoping will avoid the polyfill, but I'll need to check that.

IE11 is the only place we'd use a non-native Promise, and it happens to support `setImmediate`, so I'm thinking this change should give us slightly better performance, and certainly more predictable performance than setTimeout.

In the near-but-not-immediate future I'd like to move to a babel polyfill for this--only in the `es5` version of our lib, native in `modern`--but for now I think this takes care of the biggest problems.

cc @bathos 